### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.9+1] - May, 30, 2022
+
+* Automated dependency updates
+
+
 ## [2.0.9] - May 14th, 2022
 
 * Flutter 3.0
@@ -171,3 +176,4 @@
 ## [1.0.0] - October 31st, 2020
 
 * Splitted several core models out to be pure dart compatible.
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,25 +1,23 @@
-name: automated_testing_framework_models
-description: Core models for the automated testing framework to provide pure dart support for server side integrations.
-version: 2.0.9
-homepage: https://github.com/peiffer-innovations/automated_testing_framework_models
+name: 'automated_testing_framework_models'
+description: 'Core models for the automated testing framework to provide pure dart support for server side integrations.'
+version: '2.0.9+1'
+homepage: 'https://github.com/peiffer-innovations/automated_testing_framework_models'
 
-environment:
+environment: 
   sdk: '>=2.17.0 <3.0.0'
 
-dependencies:
-  convert: ^3.0.1
-  json_class: ^2.1.2+4
-  logging: ^1.0.1
-  meta: ^1.7.0
-  pointycastle: ^3.6.0
-  uuid: ^3.0.6
+dependencies: 
+  convert: '^3.0.2'
+  json_class: '^2.1.2+4'
+  logging: '^1.0.2'
+  meta: '^1.7.0'
+  pointycastle: '^3.6.0'
+  uuid: '^3.0.6'
 
-dev_dependencies:
-  test: ^1.21.1
+dev_dependencies: 
+  test: '^1.21.1'
 
-ignore_updates:
-  # Ignoring everything in flutter_test as those are all point-in-time entries
-  # can't upgrade without upgrading Flutter itself.
+ignore_updates: 
   - 'async'
   - 'boolean_selector'
   - 'characters'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `convert`: 3.0.1 --> 3.0.2
  * `logging`: 1.0.1 --> 1.0.2


Analysis Successful

