### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.9+8] - September 13, 2022
+
+* Automated dependency updates
+
+
 ## [2.0.9+7] - September 6, 2022
 
 * Automated dependency updates
@@ -206,6 +211,7 @@
 ## [1.0.0] - October 31st, 2020
 
 * Splitted several core models out to be pure dart compatible.
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'automated_testing_framework_models'
 description: 'Core models for the automated testing framework to provide pure dart support for server side integrations.'
-version: '2.0.9+7'
+version: '2.0.9+8'
 homepage: 'https://github.com/peiffer-innovations/automated_testing_framework_models'
 
 environment: 
@@ -8,14 +8,14 @@ environment:
 
 dependencies: 
   convert: '^3.0.2'
-  json_class: '^2.1.2+9'
+  json_class: '^2.1.2+10'
   logging: '^1.0.2'
   meta: '^1.7.0'
-  pointycastle: '^3.6.1'
+  pointycastle: '^3.6.2'
   uuid: '^3.0.6'
 
 dev_dependencies: 
-  test: '^1.21.5'
+  test: '^1.21.6'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `json_class`: 2.1.2+9 --> 2.1.2+10
  * `pointycastle`: 3.6.1 --> 3.6.2

dev_dependencies:
  * `test`: 1.21.5 --> 1.21.6


Analysis Successful

